### PR TITLE
Adjust Regex to match trailing appliance-mfa in private envs

### DIFF
--- a/GuardianAppSwiftUI/ContentView.swift
+++ b/GuardianAppSwiftUI/ContentView.swift
@@ -167,7 +167,7 @@ struct ContentView: View {
 
     func extractEmailAndDomain(from urlString: String) -> (email: String?, domain: String?) {
         let percentEncodingRemoved = urlString.removingPercentEncoding!
-        let pattern = "otpauth://totp/.+?:(.+?)\\?enrollment_tx_id=.+?&base_url=https?://([^/]+).*"
+        let pattern = "otpauth://totp/.+?:(.+?)\\?enrollment_tx_id=.+?&base_url=https?://([^/]+.*)"
         let regex = try! NSRegularExpression(pattern: pattern, options: [])
         let range = NSRange(location: 0, length: percentEncodingRemoved.count)
         guard let match = regex.firstMatch(in: percentEncodingRemoved, options: [], range: range) else {


### PR DESCRIPTION
Adjusted the regex that extracts the domain from the QR Code URI.
This will now match trailing appliance-mfa for private environments like {domain}/appliance-mfa.